### PR TITLE
fix: compatible with windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export default (api: IApi) => {
 
     const { execSync } = require('child_process');
     execSync(
-      "npx eslint src/ --ext .tsx,.ts --rule '@typescript-eslint/consistent-type-exports: error'",
+      "npx eslint src/ --ext .tsx,.ts --rule \"@typescript-eslint/consistent-type-exports: error\"",
       {
         cwd: process.cwd(),
         env: process.env,


### PR DESCRIPTION
最新的react-component/slider用了这个，我的windows一直没法compile
![image](https://github.com/react-component/father-plugin/assets/36807043/a07e398f-fd2a-4a28-bc3c-b3ef5bb7e23e)
