### PR TITLE
fix: skip if eslint is not installed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,19 @@ export default (api: IApi) => {
       api?.config?.esm?.input || api?.config?.esm?.input || 'src/';
 
     const { execSync } = require('child_process');
-    execSync(
-      `npx eslint ${inputFolder} --ext .tsx,.ts --rule '@typescript-eslint/consistent-type-exports: error'`,
-      {
-        cwd: process.cwd(),
-        env: process.env,
-        stdio: [process.stdin, process.stdout, process.stderr],
-        encoding: 'utf-8',
-      },
-    );
+    try {
+      execSync(
+        `npx eslint ${inputFolder} --ext .tsx,.ts --rule '@typescript-eslint/consistent-type-exports: error'`,
+        {
+          cwd: process.cwd(),
+          env: process.env,
+          stdio: [process.stdin, process.stdout, process.stderr],
+          encoding: 'utf-8',
+        },
+      );
+    } catch (error) {
+      console.log('ESLint is not installed, skip.');
+    }
   });
 
   // modify default build config for all rc projects


### PR DESCRIPTION
https://github.com/ant-design/x/actions/runs/10863408629/job/30147530334?pr=119

```
error - Error: Command failed: npx eslint components/ --ext .tsx,.ts --rule '@typescript-eslint/consistent-type-exports: error'
    at checkExecSyncError (node:child_process:890:11)
    at execSync (node:child_process:962:15)
    at Hook.fn (/home/runner/work/x/x/node_modules/@rc-component/father-plugin/dist/index.js:43:5)
    at /home/runner/work/x/x/node_modules/@umijs/core/dist/service/service.js:184:26
    at _next1 (eval at create (/home/runner/work/x/x/node_modules/@umijs/bundler-utils/compiled/tapable/index.js:1:8472), <anonymous>:17:17)
    at eval (eval at create (/home/runner/work/x/x/node_modules/@umijs/bundler-utils/compiled/tapable/index.js:1:8472), <anonymous>:42:1)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 2077,
  stdout: null,
  stderr: null
}
error: script "compile" exited with code 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 增强了 ESLint 执行的错误处理，提供了更清晰的错误反馈。
- **错误修复**
	- 通过添加 `try-catch` 块，防止因 ESLint 未安装或执行问题导致的程序崩溃。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->