### PR TITLE
Revert "fix: skip if eslint is not installed"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,19 +11,15 @@ export default (api: IApi) => {
       api?.config?.esm?.input || api?.config?.esm?.input || 'src/';
 
     const { execSync } = require('child_process');
-    try {
-      execSync(
-        `npx eslint ${inputFolder} --ext .tsx,.ts --rule '@typescript-eslint/consistent-type-exports: error'`,
-        {
-          cwd: process.cwd(),
-          env: process.env,
-          stdio: [process.stdin, process.stdout, process.stderr],
-          encoding: 'utf-8',
-        },
-      );
-    } catch (error) {
-      console.log('ESLint is not installed, skip.');
-    }
+    execSync(
+      `npx eslint ${inputFolder} --ext .tsx,.ts --rule '@typescript-eslint/consistent-type-exports: error'`,
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        stdio: [process.stdin, process.stdout, process.stderr],
+        encoding: 'utf-8',
+      },
+    );
   });
 
   // modify default build config for all rc projects


### PR DESCRIPTION
Reverts react-component/father-plugin#7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修改了 ESLint 命令的错误处理逻辑，移除了原有的异常捕获机制，直接调用命令，可能导致未处理的异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->