### PR TITLE
refactor: Use inline eslint called

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from 'father';
+import path from 'path';
 
 export default defineConfig({
   cjs: { output: 'dist' },
-  targets: {
-    chrome: 85,
-  },
+  plugins: [path.resolve(__dirname, 'src')],
 });

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ]
   },
   "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
     "eslint": "^8.23.0",
     "fs-extra": "^11.3.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "father build",
+    "build": "cross-env CHECK_TS_ONLY=1 father build",
     "dev": "father dev",
     "lint:es": "eslint \"{src,test}/**/*.{js,jsx,ts,tsx}\"",
     "prepare": "husky install",
@@ -35,13 +35,17 @@
     ]
   },
   "dependencies": {
+    "@typescript-eslint/parser": "^8.28.0",
+    "eslint": "^8.23.0",
     "fs-extra": "^11.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
+    "@types/eslint": "^8.56.12",
+    "@types/fs-extra": "^11.0.4",
     "@umijs/lint": "^4",
-    "eslint": "^8.23.0",
+    "cross-env": "^7.0.3",
     "father": "^4.1.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
+    "chalk": "^4.1.2",
     "eslint": "^8.23.0",
     "fs-extra": "^11.3.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,9 @@ export default (api: IApi) => {
         parserOptions: {
           ecmaVersion: 2021,
           sourceType: 'module',
+          project: './tsconfig.json',
         },
+        plugins: ['@typescript-eslint'],
       },
       extensions: ['tsx', 'ts'],
     });


### PR DESCRIPTION
antd 用的 eslint 9 会导致配置冲突启动不起来，改成 plugin 自带 eslint module 进行检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 更新了构建配置和依赖管理，实现了更精准的 TypeScript 检查和环境变量控制。
  - 调整了项目配置策略，从目标版本转为插件机制，提高了集成灵活性。

- **Refactor**
  - 改进了代码中 lint 检查的流程，提供了更清晰、彩色化的错误提示，便于快速识别问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->