### PR TITLE
revert: #15

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'father';
-import path from 'path';
 
 export default defineConfig({
   cjs: { output: 'dist' },
-  plugins: [path.resolve(__dirname, 'src')],
 });

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "cross-env CHECK_TS_ONLY=1 father build",
+    "build": "father build",
     "dev": "father dev",
     "lint:es": "eslint \"{src,test}/**/*.{js,jsx,ts,tsx}\"",
     "prepare": "husky install",
-    "prepublishOnly": "cross-env CHECK_TS_ONLY=1 father doctor && npm run build"
+    "prepublishOnly": "father doctor && npm run build"
   },
   "commitlint": {
     "extends": [
@@ -35,10 +35,7 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.28.0",
-    "@typescript-eslint/parser": "^8.28.0",
     "chalk": "^4.1.2",
-    "eslint": "^8.23.0",
     "fs-extra": "^11.3.0"
   },
   "devDependencies": {
@@ -47,7 +44,6 @@
     "@types/eslint": "^8.56.12",
     "@types/fs-extra": "^11.0.4",
     "@umijs/lint": "^4",
-    "cross-env": "^7.0.3",
     "father": "^4.1.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rc-component/father-plugin",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "The father plugin for all react-component projects",
   "keywords": [],
   "repository": "https://github.com/react-component/father-plugin.git",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/eslint": "^8.56.12",
     "@types/fs-extra": "^11.0.4",
     "@umijs/lint": "^4",
+    "eslint": "^8.23.0",
     "father": "^4.1.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import chalk from 'chalk';
-import { ESLint } from 'eslint';
+import { execSync } from 'child_process';
 import type { IApi } from 'father';
 import fs from 'fs-extra';
 import path from 'path';
@@ -37,101 +36,41 @@ export default (api: IApi) => {
     const inputFolder =
       api?.config?.esm?.input || api?.config?.esm?.input || 'src/';
 
-    const eslint = new ESLint({
-      useEslintrc: false,
-      errorOnUnmatchedPattern: false,
-      overrideConfig: {
-        ignorePatterns: ['__tests__', 'demo', 'locale'],
-        rules: {
-          '@typescript-eslint/consistent-type-exports': ['error'],
+    const isEslintInstalled = checkNpmPackageDependency(packageJson, 'eslint');
+    if (isEslintInstalled) {
+      execSync(
+        // Requires compatibility with Windows environment
+        `npx eslint ${inputFolder} --ext .tsx,.ts --rule "@typescript-eslint/consistent-type-exports: error"`,
+        {
+          cwd,
+          env: process.env,
+          stdio: [process.stdin, process.stdout, process.stderr],
+          encoding: 'utf-8',
         },
-        parser: '@typescript-eslint/parser',
-        parserOptions: {
-          ecmaVersion: 2021,
-          sourceType: 'module',
-          project: './tsconfig.json',
-        },
-        plugins: ['@typescript-eslint'],
-      },
-      extensions: ['tsx', 'ts'],
-    });
-
-    const results = await eslint.lintFiles([inputFolder]);
-
-    // Collect eslint errors
-    interface ErrorInfo {
-      line: number;
-      text: string;
-      error: string;
-    }
-    const errorMessages: {
-      filePath: string;
-      errors: ErrorInfo[];
-    }[] = [];
-
-    results.forEach((result) => {
-      const fullText = result.source || '';
-      const textLines = fullText.split('\n');
-
-      const errorInfos: ErrorInfo[] = [];
-
-      result.messages.forEach((message) => {
-        if (/Definition for rule .* was not found./.test(message.message)) {
-          return;
-        }
-
-        errorInfos.push({
-          line: message.line,
-          text: textLines[message.line - 1],
-          error: message.message,
-        });
-      });
-
-      if (errorInfos.length) {
-        errorMessages.push({
-          filePath: result.filePath,
-          errors: errorInfos,
-        });
-      }
-    });
-
-    if (errorMessages.length) {
-      console.log('');
-      console.log(chalk.red('Eslint errors:'));
-
-      errorMessages.forEach((error) => {
-        console.log(chalk.yellow(`${error.filePath}`));
-        error.errors.forEach((item) => {
-          console.log(`${item.line}: ${item.text.trim()}`);
-          console.log(chalk.gray(`${item.error}`));
-        });
-        console.log('');
-      });
-
-      process.exit(1);
+      );
+    } else {
+      console.log('ESLint is not installed, skip.');
     }
   });
 
   // modify default build config for all rc projects
-  if (!process.env.CHECK_TS_ONLY) {
-    api.modifyDefaultConfig((memo) => {
-      Object.assign(memo, {
-        esm: {
-          output: 'es',
-          // transform all rc-xx/lib to rc-xx/es for esm build
-          extraBabelPlugins: [require.resolve('./babelPluginImportLib2Es')],
-        },
-        cjs: {
-          // specific platform to browser, father 4 build cjs for node by default
-          platform: 'browser',
-          output: 'lib',
-        },
-        targets: {
-          chrome: 85,
-        },
-      } as typeof memo);
+  api.modifyDefaultConfig((memo) => {
+    Object.assign(memo, {
+      esm: {
+        output: 'es',
+        // transform all rc-xx/lib to rc-xx/es for esm build
+        extraBabelPlugins: [require.resolve('./babelPluginImportLib2Es')],
+      },
+      cjs: {
+        // specific platform to browser, father 4 build cjs for node by default
+        platform: 'browser',
+        output: 'lib',
+      },
+      targets: {
+        chrome: 85,
+      },
+    } as typeof memo);
 
-      return memo;
-    });
-  }
+    return memo;
+  });
 };


### PR DESCRIPTION
antd 继续使用 antd-tools，这里的内置 eslint 不再需要。同时回滚也解决其他 rc 组件库 eslint 依赖冲突的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 更新了应用版本号及构建命令，从而简化了构建流程。
  - 优化了依赖管理，移除不必要的依赖包，实现依赖关系的精简。
  - 调整了代码检查流程，重构了 ESLint 集成以提升执行效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->