### PR TITLE
chore: forbid rc deep imports in build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,33 @@ import path from 'path';
 
 const cwd = process.cwd();
 
+const restrictedPackageDirectoryImports = [
+  '@rc-component/*/es',
+  '@rc-component/*/es/**',
+  '@rc-component/*/lib',
+  '@rc-component/*/lib/**',
+  'rc-*/es',
+  'rc-*/es/**',
+  'rc-*/lib',
+  'rc-*/lib/**',
+];
+
+const eslintRulesString = JSON.stringify({
+  '@typescript-eslint/consistent-type-exports': 'error',
+  'no-restricted-imports': [
+    'error',
+    {
+      patterns: [
+        {
+          group: restrictedPackageDirectoryImports,
+          message:
+            'Do not import package internals from es/lib. Import from the package root.',
+        },
+      ],
+    },
+  ],
+}).replace(/"/g, '\\"');
+
 // 检查 package.json 中是否有指定的 npm 包依赖
 function checkNpmPackageDependency(packageJson: any, packageName: string) {
   return !!(
@@ -20,7 +47,7 @@ export default (api: IApi) => {
       return;
     }
 
-    console.log('Check Typescript exports...');
+    console.log('Check Typescript exports and rc package directory imports...');
 
     // Break if current project not install `@rc-component/np`
     const packageJson = await fs.readJson(path.join(cwd, 'package.json'));
@@ -40,7 +67,7 @@ export default (api: IApi) => {
     if (isEslintInstalled) {
       execSync(
         // Requires compatibility with Windows environment
-        `npx eslint ${inputFolder} --ext .tsx,.ts --rule "@typescript-eslint/consistent-type-exports: error"`,
+        `npx eslint ${inputFolder} --ext .tsx,.ts --rule "${eslintRulesString}"`,
         {
           cwd,
           env: process.env,


### PR DESCRIPTION
## 背景

rc 包之间不应该依赖其他包的 `es` / `lib` 构建产物内部路径。此前这类限制需要在各个包的 ESLint 配置里重复添加，容易遗漏。

## 改动内容

- 在 `@rc-component/father-plugin` 的 build 阶段 ESLint 检查中加入 `no-restricted-imports` 规则。
- 禁止 `@rc-component/*` 和 `rc-*` 包的 `es` / `lib` 深路径导入。
- 保留原有 `@typescript-eslint/consistent-type-exports` 检查，并仍然只扫描 `.ts` / `.tsx`。

## 验证

- `npm run lint:es`
- `npm run build`
- 在 `rc-motion` 中安装本地 tarball 后执行 `npm run compile`，正常通过。
- 在 `rc-motion` 中临时添加 `@rc-component/util/es/raf` 导入后，`npm run compile` 会被新增规则拦截；删除临时文件后恢复通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **代码质量改进**
  * 优化代码检查工具配置，增强了对导入模式的限制规则，以提高代码库的一致性和维护性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/father-plugin/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->